### PR TITLE
closed #225 검색을 취소하고, 다시 상권 검색시에 매물 찾기가 되는 버그 방지

### DIFF
--- a/app/src/main/java/kr/co/connect/boostcamp/livewhere/ui/map/MapViewModel.kt
+++ b/app/src/main/java/kr/co/connect/boostcamp/livewhere/ui/map/MapViewModel.kt
@@ -484,6 +484,7 @@ class MapViewModel(val mapRepository: MapRepositoryImpl) : BaseViewModel(),
     }
 
     override fun makeDefaultStatus() {
+        _markerLiveData.postValue(null)
         _userStatusLiveData.postValue(UserStatus(StatusCode.DEFAULT_SEARCH, ""))
         _searchListLiveData.postValue(listOf(EmptyInfo("")))
     }


### PR DESCRIPTION
## 개요
- #225 검색을 취소하고, 다시 상권 검색시에 매물 찾기가 되는 버그 방지 

## 작업 사항
- #225 검색을 취소하고, 다시 상권 검색시에 매물 찾기가 되는 버그 방지 로직 추가
